### PR TITLE
Fix node reference in env.go

### DIFF
--- a/src/env.go
+++ b/src/env.go
@@ -41,7 +41,7 @@ func (env *Env) BuildData(node etcd.Node, prefix string, data map[string]interfa
 
 		if node.Dir {
 			data[key] = make(map[string]interface{})
-			env.BuildData(node, prefix+"/"+key, data[key].(map[string]interface{}))
+			env.BuildData(*node, prefix+"/"+key, data[key].(map[string]interface{}))
 		} else {
 			data[key] = node.Value
 		}

--- a/src/env_test.go
+++ b/src/env_test.go
@@ -39,8 +39,8 @@ func TestBuildData(t *testing.T) {
 	env := Env{}
 
 	hostnameNode := etcd.Node{Key: "/rails/mongodb/hostname", Value: "localhost"}
-	mongoDbNode := etcd.Node{Key: "/rails/mongodb", Dir: true, Nodes: etcd.Nodes{hostnameNode}}
-	dirNode := etcd.Node{Dir: true, Nodes: etcd.Nodes{mongoDbNode}}
+	mongoDbNode := etcd.Node{Key: "/rails/mongodb", Dir: true, Nodes: etcd.Nodes{&hostnameNode}}
+	dirNode := etcd.Node{Dir: true, Nodes: etcd.Nodes{&mongoDbNode}}
 
 	data := map[string]interface{}{}
 	env.BuildData(dirNode, "/rails", data)


### PR DESCRIPTION
Almost too trivial for a pull request, but to make it easy ... 

I found this change necessary to build on go version go1.3 darwin/amd64

This fixes the error I mentioned in #1. 
